### PR TITLE
Fix for multiple triggers with different schemas in same application

### DIFF
--- a/trigger/graphql/metadata.go
+++ b/trigger/graphql/metadata.go
@@ -6,12 +6,12 @@ import (
 
 // Settings for trigger
 type Settings struct {
-	Port             int    `md:"port,required"`          // The port to listen on for requests
-	Path             string `md:"path,required"`          // The HTTP resource path
-	SecureConnection bool   `md:"secureConnection"`       // Set to "true" for a secure connection
-	ServerKey        string `md:"serverKey"`              // A PEM encoded private key file
-	CACertificate    string `md:"caCertificate"`          // A PEM encoded CA or Server certificate file
-	GraphQLSchema    string `md:"graphqlSchema,required"` // The GraphQL schema for the trigger
+	Port             int    `md:"port,required"`             // The port to listen on for requests
+	Path             string `md:"path,required"`             // The HTTP resource path
+	SecureConnection bool   `md:"secureConnection,required"` // Set to "true" for a secure connection
+	ServerKey        string `md:"serverKey"`                 // A PEM encoded private key file
+	CACertificate    string `md:"caCertificate"`             // A PEM encoded CA or Server certificate file
+	GraphQLSchema    string `md:"graphqlSchema,required"`    // The GraphQL schema for the trigger
 }
 
 // HandlerSettings for trigger

--- a/trigger/graphql/server.go
+++ b/trigger/graphql/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -69,11 +70,11 @@ func (s *Server) Start() error {
 
 	if s.secureConnection {
 		logger.RootLogger().Debug("Reading certificates")
-		privateKey, err := decodeCerts(s.serverKey)
+		privateKey, err := s.decodeCertificate(s.serverKey)
 		if err != nil {
 			return err
 		}
-		CACertificate, err := decodeCerts(s.caCertificate)
+		CACertificate, err := s.decodeCertificate(s.caCertificate)
 		if err != nil {
 			return err
 		}
@@ -170,6 +171,61 @@ func (s *Server) WaitStop(timeout time.Duration) error {
 	}
 }
 
+func (s *Server) decodeCertificate(cert string) ([]byte, error) {
+	if cert == "" {
+		return nil, fmt.Errorf("Certificate is Empty")
+	}
+
+	// case 1: if certificate comes from fileselctor it will be base64 encoded
+	if strings.HasPrefix(cert, "{") {
+		logger.RootLogger().Debug("Certificate received from file selector")
+		certObj, err := coerce.ToObject(cert)
+		if err == nil {
+			certValue, ok := certObj["content"].(string)
+			if !ok || certValue == "" {
+				return nil, fmt.Errorf("No content found for certificate")
+			}
+			return base64.StdEncoding.DecodeString(strings.Split(certValue, ",")[1])
+		}
+		return nil, err
+	}
+
+	// case 2: if the certificate is defined as application property in the format "<encoding>,<encodedCertificateValue>"
+	index := strings.IndexAny(cert, ",")
+	if index > -1 {
+		//some encoding is there
+		logger.RootLogger().Debug("Certificate received from application property with encoding")
+		encoding := cert[:index]
+		certValue := cert[index+1:]
+
+		if strings.EqualFold(encoding, "base64") {
+			return base64.StdEncoding.DecodeString(certValue)
+		}
+		return nil, fmt.Errorf("Error parsing the certificate or given encoding may not be supported")
+	}
+
+	// case 3: if the certificate is defined as application property that points to a file
+	if strings.HasPrefix(cert, "file://") {
+		// app property pointing to a file
+		logger.RootLogger().Debug("Certificate received from application property pointing to a file")
+		fileName := cert[7:]
+		return ioutil.ReadFile(fileName)
+	}
+
+	// case 4: if certificate is defined as path to a file (in oss)
+	if strings.Contains(cert, "/") || strings.Contains(cert, "\\") {
+		logger.RootLogger().Debug("Certificate received from settings as file path")
+		_, err := os.Stat(cert)
+		if err != nil {
+			logger.RootLogger().Errorf("Cannot find certificate file: %s", err.Error())
+		}
+		return ioutil.ReadFile(cert)
+	}
+
+	logger.RootLogger().Debug("Certificate received from application property without encoding")
+	return []byte(cert), nil
+}
+
 type serverHandler struct {
 	handler          http.Handler
 	clientsGroup     chan bool
@@ -185,47 +241,4 @@ func (sh *serverHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Server-Instance-Id", sh.serverInstanceID)
 
 	sh.handler.ServeHTTP(w, r)
-}
-
-func decodeCerts(certVal string) ([]byte, error) {
-	if certVal == "" {
-		return nil, fmt.Errorf("Certificate is Empty")
-	}
-
-	//if certificate comes from fileselctor it will be base64 encoded
-	if strings.HasPrefix(certVal, "{") {
-		logger.RootLogger().Debug("Certificate received from FileSelector")
-		certObj, err := coerce.ToObject(certVal)
-		if err == nil {
-			certRealValue, ok := certObj["content"].(string)
-			logger.RootLogger().Debug("Fetched Content from Certificate Object")
-			if !ok || certRealValue == "" {
-				return nil, fmt.Errorf("Didn't find the certificate content")
-			}
-
-			index := strings.IndexAny(certRealValue, ",")
-			if index > -1 {
-				certRealValue = certRealValue[index+1:]
-			}
-
-			return base64.StdEncoding.DecodeString(certRealValue)
-		}
-		return nil, err
-	}
-
-	//if the certificate comes from application properties need to check whether that it contains , ans encoding
-	index := strings.IndexAny(certVal, ",")
-
-	if index > -1 {
-		//some encoding is there
-		logger.RootLogger().Debug("Certificate received from App properties with encoding")
-		encoding := certVal[:index]
-		certRealValue := certVal[index+1:]
-
-		if strings.EqualFold(encoding, "base64") {
-			return base64.StdEncoding.DecodeString(certRealValue)
-		}
-		return nil, fmt.Errorf("Error in parsing the certificates or we may be not be supporting the given encoding")
-	}
-	return []byte(certVal), nil
 }

--- a/trigger/graphql/utils.go
+++ b/trigger/graphql/utils.go
@@ -6,23 +6,23 @@ import (
 )
 
 // CoerceType converts ast.Type to graphql.Type
-func CoerceType(typ ast.Type) graphql.Type {
+func CoerceType(typ ast.Type, typMap map[string]graphql.Type) graphql.Type {
 	switch typ.GetKind() {
 	case "Named":
 		if IsScalarType(typ.(*ast.Named).Name.Value) {
 			return CoerceScalarType(typ.(*ast.Named).Name.Value)
 		}
-		if t, ok := gqlTypMap[typ.(*ast.Named).Name.Value]; ok {
+		if t, ok := typMap[typ.(*ast.Named).Name.Value]; ok {
 			return t
 		}
 		return nil
 	case "List":
 		return &graphql.List{
-			OfType: CoerceType(typ.(*ast.List).Type),
+			OfType: CoerceType(typ.(*ast.List).Type, typMap),
 		}
 	case "NonNull":
 		return &graphql.NonNull{
-			OfType: CoerceType(typ.(*ast.NonNull).Type),
+			OfType: CoerceType(typ.(*ast.NonNull).Type, typMap),
 		}
 	}
 	return nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
When an application is built using multiple graphql triggers with different schemas, only one endpoint is exposed since all the trigger level settings are global variables in trigger.go
**What is the new behavior?**
Moved all the global variables into trigger settings and made necessary changes in affected files. With this change, the user can define a single application with multiple graphql triggers with different schemas and each exposing a unique working endpoint.
